### PR TITLE
Update CP_parallel utility script to include plugins directory

### DIFF
--- a/3.cellprofiler_analysis/notebooks/run_cellprofiler_analysis.ipynb
+++ b/3.cellprofiler_analysis/notebooks/run_cellprofiler_analysis.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +52,12 @@
     "output_dir.mkdir(exist_ok=True, parents=True)\n",
     "\n",
     "# directory where images are located within folders\n",
-    "images_dir = pathlib.Path(\"../../2.cellprofiler_ic_processing/illum_directory\")"
+    "images_dir = pathlib.Path(\n",
+    "    \"../../0.download_data\"\n",
+    ")\n",
+    "\n",
+    "# path to plugins directory as one of the pipelines uses the RunCellpose plugin\n",
+    "plugins_dir = pathlib.Path(\"/home/jenna/Desktop/Github/CellProfiler/cellprofiler/modules/plugins\")"
    ]
   },
   {
@@ -64,9 +69,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   '20231017ChromaLive_6hr_4ch_MaxIP': {   'path_to_images': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/0.download_data/20231017ChromaLive_6hr_4ch_MaxIP'),\n",
+      "                                            'path_to_output': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/3.cellprofiler_analysis/analysis_output/20231017ChromaLive_6hr_4ch_MaxIP'),\n",
+      "                                            'path_to_pipeline': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/3.cellprofiler_analysis/pipelines/analysis_4ch.cppipe')},\n",
+      "    'run_20230920ChromaLiveTL_24hr4ch_MaxIP': {   'path_to_images': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/0.download_data/20230920ChromaLiveTL_24hr4ch_MaxIP'),\n",
+      "                                                  'path_to_output': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/3.cellprofiler_analysis/analysis_output/20230920ChromaLiveTL_24hr4ch_MaxIP'),\n",
+      "                                                  'path_to_pipeline': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/3.cellprofiler_analysis/pipelines/analysis_4ch.cppipe')},\n",
+      "    'run_20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP': {   'path_to_images': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/0.download_data/20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP'),\n",
+      "                                                                'path_to_output': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/3.cellprofiler_analysis/analysis_output/20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP'),\n",
+      "                                                                'path_to_pipeline': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/3.cellprofiler_analysis/pipelines/analysis_2ch.cppipe')},\n",
+      "    'run_20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP_whole_image': {   'path_to_images': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/0.download_data/20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP'),\n",
+      "                                                                            'path_to_output': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/3.cellprofiler_analysis/analysis_output/20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP_whole_image'),\n",
+      "                                                                            'path_to_pipeline': PosixPath('/home/jenna/live_cell_timelapse_apoptosis/3.cellprofiler_analysis/pipelines/analysis_2ch_image.cppipe')}}\n"
+     ]
+    }
+   ],
    "source": [
     "dict_of_inputs = {\n",
     "    \"run_20230920ChromaLiveTL_24hr4ch_MaxIP\": {\n",
@@ -90,7 +114,7 @@
     "    \"run_20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP\": {\n",
     "        \"path_to_images\": pathlib.Path(\n",
     "            f\"{images_dir}/20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP/\"\n",
-    "        ).resolve(),\n",
+    "        ).resolve(strict=True),\n",
     "        \"path_to_output\": pathlib.Path(\n",
     "            f\"{output_dir}/20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP/\"\n",
     "        ).resolve(),\n",
@@ -130,7 +154,9 @@
    "outputs": [],
    "source": [
     "cp_parallel.run_cellprofiler_parallel(\n",
-    "    plate_info_dictionary=dict_of_inputs, run_name=run_name\n",
+    "    plate_info_dictionary=dict_of_inputs,\n",
+    "    run_name=run_name,\n",
+    "    plugins_dir=plugins_dir,\n",
     ")"
    ]
   }
@@ -151,7 +177,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.19"
   },
   "orig_nbformat": 4
  },

--- a/3.cellprofiler_analysis/pipelines/analysis_2ch.cppipe
+++ b/3.cellprofiler_analysis/pipelines/analysis_2ch.cppipe
@@ -8,7 +8,7 @@ HasImagePlaneDetails:False
 Images:[module_num:1|svn_version:'Unknown'|variable_revision_number:2|show_window:False|notes:['Module notes are provided by Jenna Tomkinson.', '', 'Images module is left blank since we are giving the path to the images in the CLI command.', '', '']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
     :
     Filter images?:Images only
-    Select the rule criteria:and (extension does isimage) (directory doesnot containregexp "[\\\\/]\\.")
+    Select the rule criteria:and (extension does isimage) (file does startwith "C-02") (file does contain "T0001")
 
 Metadata:[module_num:2|svn_version:'Unknown'|variable_revision_number:6|show_window:False|notes:['Metadata is extracted from the file names using regular expressions. Metadata included are well, FOV, time, and z-slice, and channel.']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
     Extract metadata?:Yes

--- a/3.cellprofiler_analysis/pipelines/analysis_4ch.cppipe
+++ b/3.cellprofiler_analysis/pipelines/analysis_4ch.cppipe
@@ -7,7 +7,7 @@ HasImagePlaneDetails:False
 
 Images:[module_num:1|svn_version:'Unknown'|variable_revision_number:2|show_window:False|notes:['Module notes are provided by Jenna Tomkinson.', '', 'Images module is left blank since we are giving the path to the images in the CLI command']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]
     :
-    Filter images?:Custom
+    Filter images?:Images only
     Select the rule criteria:and (extension does isimage) (file does startwith "C-07")
 
 Metadata:[module_num:2|svn_version:'Unknown'|variable_revision_number:6|show_window:False|notes:['Metadata is extracted from the file names using regular expressions. Metadata includes well, FOV, time, z-slice, and channel.']|batch_state:array([], dtype=uint8)|enabled:True|wants_pause:False]

--- a/3.cellprofiler_analysis/scripts/run_cellprofiler_analysis.py
+++ b/3.cellprofiler_analysis/scripts/run_cellprofiler_analysis.py
@@ -5,7 +5,7 @@
 
 # ## Import libraries
 
-# In[ ]:
+# In[1]:
 
 
 import pathlib
@@ -18,7 +18,7 @@ import cp_parallel
 
 # ## Set paths and variables
 
-# In[ ]:
+# In[2]:
 
 
 # set the run type for the parallelization
@@ -29,12 +29,17 @@ output_dir = pathlib.Path("../analysis_output")
 output_dir.mkdir(exist_ok=True, parents=True)
 
 # directory where images are located within folders
-images_dir = pathlib.Path("../../2.cellprofiler_ic_processing/illum_directory")
+images_dir = pathlib.Path(
+    "../../0.download_data"
+)
+
+# path to plugins directory as one of the pipelines uses the RunCellpose plugin
+plugins_dir = pathlib.Path("/home/jenna/Desktop/Github/CellProfiler/cellprofiler/modules/plugins")
 
 
 # ## Create dictionary with all info for each plate
 
-# In[ ]:
+# In[3]:
 
 
 dict_of_inputs = {
@@ -59,7 +64,7 @@ dict_of_inputs = {
     "run_20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP": {
         "path_to_images": pathlib.Path(
             f"{images_dir}/20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP/"
-        ).resolve(),
+        ).resolve(strict=True),
         "path_to_output": pathlib.Path(
             f"{output_dir}/20231017ChromaLive_endpoint_w_AnnexinV_2ch_MaxIP/"
         ).resolve(),
@@ -90,6 +95,8 @@ pprint.pprint(dict_of_inputs, indent=4)
 
 
 cp_parallel.run_cellprofiler_parallel(
-    plate_info_dictionary=dict_of_inputs, run_name=run_name
+    plate_info_dictionary=dict_of_inputs,
+    run_name=run_name,
+    plugins_dir=plugins_dir,
 )
 

--- a/utils/cp_parallel.py
+++ b/utils/cp_parallel.py
@@ -1,6 +1,8 @@
 """
 This collection of functions runs CellProfiler in parallel and can convert the results into log files
 for each process.
+
+Developed from NF1 repository script made by Jenna Tomkinson.
 """
 
 import logging
@@ -9,7 +11,7 @@ import os
 import pathlib
 import subprocess
 from concurrent.futures import Future, ProcessPoolExecutor
-from typing import List
+from typing import List, Optional, Union
 
 from exceptions import MaxWorkerError
 
@@ -22,9 +24,12 @@ def results_to_log(
     convert into a log file for each process.
 
     Args:
-        results (List[subprocess.CompletedProcess]): the outputs from a subprocess.run
-        log_dir (pathlib.Path): directory for log files
-        run_name (str): a given name for the type of CellProfiler run being done on the plates (example: whole image features)
+        results (List[subprocess.CompletedProcess]): 
+            the outputs from a subprocess.run.
+        log_dir (pathlib.Path): 
+            directory for log files.
+        run_name (str): 
+            a given name for the type of CellProfiler run being done on the plates (example: whole image features).
     """
     # Access the command (args) and stderr (output) for each CompletedProcess object
     for result in results:
@@ -49,13 +54,19 @@ def results_to_log(
 def run_cellprofiler_parallel(
     plate_info_dictionary: dict,
     run_name: str,
+    plugins_dir: Optional[Union[pathlib.Path, None]] = None,
 ) -> None:
     """
     This function utilizes multi-processing to run CellProfiler pipelines in parallel.
 
     Args:
-        plate_info_dictionary (dict): dictionary with all paths for CellProfiler to run a pipeline
-        run_name (str): a given name for the type of CellProfiler run being done on the plates (example: whole image features)
+        plate_info_dictionary (dict): 
+            dictionary with all paths for CellProfiler to run a pipeline.
+        run_name (str): 
+            a given name for the type of CellProfiler run being done on the plates (example: whole image features).
+        plugins_dir (pathlib.Path, optional): 
+            if you are using a CellProfiler plugin module in your pipeline, you must specify a path to the directory. 
+            This is an optional parameter and defaults to None (no plugin dir provided).
 
     Raises:
         FileNotFoundError: if paths to pipeline and images do not exist
@@ -98,6 +109,11 @@ def run_cellprofiler_parallel(
             "-i",
             path_to_images,
         ]
+
+        # if plugins_dir is provided, add the flag to find the plugins directory with given path
+        if plugins_dir:
+            command.extend(["--plugins-directory", plugins_dir])
+
         # creates a list of commands
         commands.append(command)
 

--- a/utils/cp_parallel.py
+++ b/utils/cp_parallel.py
@@ -110,9 +110,14 @@ def run_cellprofiler_parallel(
             path_to_images,
         ]
 
-        # if plugins_dir is provided, add the flag to find the plugins directory with given path
+        # if plugins_dir is provided, check to confirm dir exists and add the flag to find the plugins directory with given path
         if plugins_dir:
-            command.extend(["--plugins-directory", plugins_dir])
+            if not pathlib.Path(plugins_dir).is_dir():
+                raise FileNotFoundError(
+                    f"Plugins directory '{pathlib.Path(plugins_dir).name}' does not exist or is not a directory"
+                    )
+            else:
+                command.extend(["--plugins-directory", plugins_dir])
 
         # creates a list of commands
         commands.append(command)


### PR DESCRIPTION
# Update CP_parallel utility script to include plugins directory

In this short PR, I have updated the CP_parallel script to include an optional parameter where you can set a path to your plugins directory when running CellProfiler headless. This was something I hadn't had before, so this is a feature enhancement to this script, which is exciting! 🎉  I have updated the cp analysis notebook for my testing, so this will need to be updated to the proper local paths when running.

I can confirm that this was working to run the 2ch pipeline using a small subset of the images.